### PR TITLE
fix: modify test importing connector using old structure

### DIFF
--- a/tests/test-app/src/queries/cat/root/cats-connection.js
+++ b/tests/test-app/src/queries/cat/root/cats-connection.js
@@ -1,4 +1,4 @@
-import paginate from 'apollo-cursor-pagination/orm-implementations/knex';
+import paginate from 'apollo-cursor-pagination/orm-connectors/knex';
 import Cat from '../../../models/Cat';
 
 export default async (_, args) => {


### PR DESCRIPTION
# Change log

`cats-connection.js` in test app now correctly imports `apollo-cursor-pagination/orm-connectors/knex`