### PR TITLE
Support nulls in knex pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cursor-pagination",
-  "version": "0.5.0-alpha-5",
+  "version": "0.5.0",
   "description": "Relay's Connection implementation for Apollo Server GraphQL library",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/apollo-cursor-pagination",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cursor-pagination",
-  "version": "0.4.5",
+  "version": "0.5.0-alpha-5",
   "description": "Relay's Connection implementation for Apollo Server GraphQL library",
   "main": "dist/index.js",
   "repository": "https://github.com/Terminal-Systems/apollo-cursor-pagination",


### PR DESCRIPTION
# Change log

- Support pagination when it contains nulls (before it would crash if sending `after` with a null value).

- Tests

![image](https://user-images.githubusercontent.com/2295137/62896455-170eea00-bd1f-11e9-9b82-9777566094c1.png)

