### PR TITLE
fix: use formatColumnFn with orderBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,47 @@ export default async (_, args) => {
 };
 ```
 
+#### Formatting Column Names
+
+If you are using something like [Objection](https://vincit.github.io/objection.js/) and have
+mapped the column names to something like snakeCase instead of camel_case, you'll want to use
+the `formatColumnFn` option to make sure you're ordering by and building cursors from the correct
+column name:
+
+```javascript
+const result = await paginate(
+  baseQuery,
+  { first, last, before, after, orderBy, orderDirection },
+  {
+    formatColumnFn: (column) => {
+      // Logic to transform your column name goes here...
+      return column
+    }
+  }
+);
+```
+
+<details>
+  <summary>An example with Objection columnNameMappers</summary>
+
+  ```javascript
+  const result = await paginate(
+    baseQuery,
+    { first, last, before, after, orderBy, orderDirection },
+    {
+      formatColumnFn: (column) => {
+        if (Model.columnNameMappers && Model.columnNameMappers.format) {
+          const result = Model.columnNameMappers.format({ [column]: true })
+          return Object.keys(result)[0]
+        } else {
+          return column
+        }
+      }
+    }
+  );
+  ```
+</details>
+
 ### Creating your own connector
 
 Only Knex.js is implemented for now. If you want to connect to a different ORM, you must make your own connector.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ const result = await paginate(
 );
 ```
 
+**Important note:** Make sure you pass the un-formatted version as your `orderBy` argument. It helps
+to create a wrapper around the `paginate()` function that enforces this. For example, if the formatted
+database column name is "created_at" and the column name on the model is "createdAt," you would pass
+"createdAt" as the `orderBy` argument.
+
 <details>
   <summary>An example with Objection columnNameMappers</summary>
 

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -114,7 +114,7 @@ const apolloCursorPaginationBuilder = ({
   if (orderColumn) {
     console.warn('"orderColumn" and "ascOrDesc" are being deprecated in favor of "orderBy" and "orderDirection" respectively');
   } else {
-    orderColumn = orderBy;
+    orderColumn = formatColumnFn ? formatColumnFn(orderBy) : orderBy;
     ascOrDesc = orderDirection;
   }
 

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -120,7 +120,7 @@ const apolloCursorPaginationBuilder = ({
     ascOrDesc = orderDirection;
   }
 
-  if (formatColumnFn && formatColumnFn(orderColumn) !== orderColumn) {
+  if (formatColumnFn && formatColumnFn(orderColumn) === orderColumn) {
     console.warn(`orderBy ${orderColumn} should not equal its formatted counterpart: ${formatColumnFn(orderColumn)}.`);
     console.warn('This may cause issues with cursors being generated properly.');
   }

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -54,7 +54,9 @@ const nodesToReturn = async (
     orderColumn, ascOrDesc, isAggregateFn, formatColumnFn,
   },
 ) => {
-  const orderedNodesAccessor = orderNodesBy(allNodesAccessor, orderColumn, ascOrDesc);
+  const orderedNodesAccessor = orderNodesBy(allNodesAccessor, {
+    orderColumn, ascOrDesc, isAggregateFn, formatColumnFn,
+  });
   const nodesAccessor = applyCursorsToNodes(
     orderedNodesAccessor,
     { before, after },
@@ -114,8 +116,13 @@ const apolloCursorPaginationBuilder = ({
   if (orderColumn) {
     console.warn('"orderColumn" and "ascOrDesc" are being deprecated in favor of "orderBy" and "orderDirection" respectively');
   } else {
-    orderColumn = formatColumnFn ? formatColumnFn(orderBy) : orderBy;
+    orderColumn = orderBy;
     ascOrDesc = orderDirection;
+  }
+
+  if (formatColumnFn && formatColumnFn(orderColumn) !== orderColumn) {
+    console.warn(`orderBy ${orderColumn} should not equal its formatted counterpart: ${formatColumnFn(orderColumn)}.`);
+    console.warn('This may cause issues with cursors being generated properly.');
   }
 
   const { nodes, hasPreviousPage, hasNextPage } = await nodesToReturn(

--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -117,13 +117,13 @@ const buildRemoveNodesFromBeforeOrAfter = (beforeOrAfter) => {
   };
 };
 
-const orderNodesBy = (nodesAccessor, orderColumn = 'id', ascOrDesc = 'asc') => {
+const orderNodesBy = (nodesAccessor, { orderColumn = 'id', ascOrDesc = 'asc', formatColumnFn }) => {
   const initialValue = nodesAccessor.clone();
   const result = operateOverScalarOrArray(initialValue, orderColumn, (orderBy, index, prev) => {
     if (index !== null) {
-      return prev.orderBy(orderBy, ascOrDesc[index]);
+      return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn), ascOrDesc[index]);
     }
-    return prev.orderBy(orderBy, ascOrDesc);
+    return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn), ascOrDesc);
   }, (prev, isArray) => (isArray ? prev.orderBy('id', ascOrDesc[0]) : prev.orderBy('id', ascOrDesc)));
   return result;
 };

--- a/src/orm-connectors/knex/offset-based-pagination.js
+++ b/src/orm-connectors/knex/offset-based-pagination.js
@@ -55,7 +55,7 @@ const getNodesLength = async (nodesAccessor) => {
   return result.length;
 };
 
-const orderNodesBy = (nodesAccessor, orderColumn = 'id', ascOrDesc = 'asc') => {
+const orderNodesBy = (nodesAccessor, { orderColumn = 'id', ascOrDesc = 'asc' }) => {
   const result = nodesAccessor.clone().orderBy(orderColumn, ascOrDesc).orderBy('id', ascOrDesc);
   return result;
 };

--- a/tests/test-app/src/queries/cat/root/cats-connection.js
+++ b/tests/test-app/src/queries/cat/root/cats-connection.js
@@ -21,7 +21,7 @@ export default async (_, args) => {
     },
     {
       isAggregateFn: column => column === 'idsum',
-      formatColumnFn: column => (column === 'idsum' ? 'sum(id)' : column),
+      formatColumnFn: column => (column === 'idsum' ? Cat.knex().raw('sum(id)') : column),
     },
   );
   return result;


### PR DESCRIPTION
When using some custom snake-case mappers with Objection JS and this package, I ran across the handy-dandy little `formatColumnFn` option!

Since the documentation didn't mention it, I updated the README to make mention of it and include a more fleshed-out example with Objection.

I also ran across an issue where it was formatting the column name everywhere else I was touching (not sure how thorough my testing was), but it wasn't using that callback function when formatting the column to `orderBy` - I just updated the main pagination function to first run the order column through the formatter before passing it to the rest of the functions.

After some quick testing on the product I'm working on, it appears to all work fine.