### PR TITLE
fix: make sure id order by column also uses formatColumnFn

### DIFF
--- a/src/orm-connectors/knex/custom-pagination.js
+++ b/src/orm-connectors/knex/custom-pagination.js
@@ -124,7 +124,9 @@ const orderNodesBy = (nodesAccessor, { orderColumn = 'id', ascOrDesc = 'asc', fo
       return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn), ascOrDesc[index]);
     }
     return prev.orderBy(formatColumnIfAvailable(orderBy, formatColumnFn), ascOrDesc);
-  }, (prev, isArray) => (isArray ? prev.orderBy('id', ascOrDesc[0]) : prev.orderBy('id', ascOrDesc)));
+  }, (prev, isArray) => (isArray
+    ? prev.orderBy(formatColumnIfAvailable('id', formatColumnFn), ascOrDesc[0])
+    : prev.orderBy(formatColumnIfAvailable('id', formatColumnFn), ascOrDesc)));
   return result;
 };
 


### PR DESCRIPTION
I noticed when joining relationships before executing cursor-pagination-enabled queries, there were some instances depending on the column where the table name was not prefixed (whenever "id" was added, for example), causing the database to throw an error about ambiguous column names.

I solved the ambiguity issue myself inside the `formatColumnFn` callback (very useful callback!), but noticed the "id" column was not using it. So I just updated it to use it.

I also checked the tests this time and they were passing for me locally!